### PR TITLE
added pointer to article on Skydive-Prometheus connector

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -118,6 +118,17 @@
 
 		<div class="row">
 			<div class="col-sm-12">
+				<h3><a href="http://skydive.network/blog/prometheus-connector.html">
+					Skydive-Prometheus Connector
+				</a></h3>
+				<p>
+This post describes the Skydive-Prometheus connector, which translates data from Skydive captured flows into a format that can be consumed by Prometheus. The first implementation of the Skydive-Prometheus connector periodically provides the byte transfer counts for each network connection under observation. The code can be easily tailored to provide additional flow information.
+				</p>
+			</div>
+		</div>
+
+		<div class="row">
+			<div class="col-sm-12">
 				<h3><a href="https://www.youtube.com/watch?v=jl2_jUKspJA">
 					Kubernetes configuration roll-out using Skydive
 				</a></h3>


### PR DESCRIPTION
We recently published a blog on the Skydive-Prometheus connector. The current PR adds a pointer to this blog to the Skydive Home page in the section on "Recent articles on Skydive". 